### PR TITLE
Add Keyword highlighting remove appnope, ligfortran from requirements

### DIFF
--- a/data/custom_widgets.py
+++ b/data/custom_widgets.py
@@ -239,8 +239,8 @@ class ReportsLabeler():
     def render_labelling_buttons(self, doc, ensure_no_duplicates=False):
         rows = []
         paragraphs = doc.split('\n\n')
-        counts = preparation.get_count_matrix(paragraphs, self.vocabulary)
-        page_keyword_count = counts.sum(axis=1)
+        counts_df = preparation.get_count_matrix(paragraphs, self.vocabulary)
+        page_keyword_count = counts_df.sum(axis=1).values
 
         def _on_button_clicked(event, number):
             paragraph_no = int(event.description)
@@ -258,7 +258,7 @@ class ReportsLabeler():
             if ensure_no_duplicates:
                 is_already_selected = True if ((self.df_labels['report_id'] == self.current_report_index) & (
                     self.df_labels['page'] == self.page_index_input_field.value) & (self.df_labels['paragraph_no'] == idx)).any() else False
-            paragraph = f"<p style='background-color: {'yellow' if page_keyword_count[idx] > 0 else 'none'};'>{paragraph}</p>"
+            paragraph = self.highlight_keywords(paragraph, idx, counts_df)
             paragraph_button = Button(
                 description=str(idx), disabled=is_already_selected)
             paragraph_button.on_click(
@@ -378,3 +378,13 @@ class ReportsLabeler():
         display(HBox((self.prev_relevant_page_button,
                       self.page_index_input_field, self.next_relevant_page_button)))
         display(self.current_page_output)
+
+    def highlight_keywords(self, paragraph, idx, counts_df):
+        if counts_df.sum(axis=1)[idx] > 0:
+            keywords = counts_df.columns[counts_df.iloc[idx,:] > 0]
+            for keyword in keywords:
+                paragraph = paragraph.replace(keyword, f"<span style='background-color: orange;'>{keyword}</span>")
+            paragraph = f"<p style='background-color: yellow;'>{paragraph}</p>"
+        else:
+            paragraph = f"<p style='background-color: none;'>{paragraph}</p>"
+        return paragraph

--- a/data/dataframe_preparation.py
+++ b/data/dataframe_preparation.py
@@ -42,7 +42,9 @@ def get_count_matrix(doc, vocabulary):
     count_vectorizer = CountVectorizer(ngram_range=(
         1, 2), vocabulary=vocabulary, tokenizer=spacy_tokenizer)
     count_matrix = count_vectorizer.fit_transform(doc)
-    return count_matrix
+    count_df = pd.DataFrame(count_matrix.toarray(
+    ), columns=count_vectorizer.get_feature_names())
+    return count_df
 
 
 def get_text_from_page(path, page_no):

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - appnope=0.1.0
   - argon2-cffi=20.1.0
   - astroid=2.4.2
   - async_generator=1.10
@@ -55,7 +54,6 @@ dependencies:
   - libcblas=3.8.0
   - libcxx=10.0.1
   - libffi=3.2.1
-  - libgfortran=4.0.0
   - libgfortran4=7.5.0
   - liblapack=3.8.0
   - libopenblas=0.3.10


### PR DESCRIPTION
- added a new method that highlights the paragraphs in yellow (no change there) and the matched keywords in orange (using a span)
- changed get_count matrix to return a data.frame in order to have the column names together with the matrix
- removed appnope=0.1.0 and libgfortran=4.0.0 from requirements